### PR TITLE
assorted updates: aperture sizes, image existence check, NaNs, masking

### DIFF
--- a/uvot-galphot/surface_phot.py
+++ b/uvot-galphot/surface_phot.py
@@ -15,6 +15,7 @@ import pdb
 
 def surface_phot(label, center_ra, center_dec, major_diam, minor_diam, pos_angle,
                      ann_width, zeropoint, zeropoint_err=0.0,
+                     aperture_factor=1.0,
                      mask_file=None, offset_file=False,
                      verbose=False):
     """
@@ -45,6 +46,10 @@ def surface_phot(label, center_ra, center_dec, major_diam, minor_diam, pos_angle
 
     zeropoint_err : float (default=0)
         uncertainty for the zeropoint
+
+    aperture_factor : float (default=1.0)
+        make the aperture larger by a factor of N (useful to quickly adjust
+        aperture if, e.g., you know R25 is too small for your UV galaxy)
 
     mask_file : string (default=None)
         path+name of ds9 region file with masks
@@ -101,7 +106,7 @@ def surface_phot(label, center_ra, center_dec, major_diam, minor_diam, pos_angle
         ellipse_center = wcs_counts.wcs_world2pix([[center_ra,center_dec]], 0)[0]
         
         # array of annuli over which to do photometry
-        annulus_array = np.arange(0, major_diam*1.2, ann_width)# * u.arcsec 
+        annulus_array = np.arange(0, major_diam*aperture_factor, ann_width)# * u.arcsec 
 
 
         

--- a/uvot-galphot/surface_phot.py
+++ b/uvot-galphot/surface_phot.py
@@ -15,7 +15,7 @@ import pdb
 
 def surface_phot(label, center_ra, center_dec, major_diam, minor_diam, pos_angle,
                      ann_width, zeropoint, zeropoint_err=0.0,
-                     aperture_factor=1.0,
+                     aperture_factor=1.0, sky_aperture_factor=1.0,
                      mask_file=None, offset_file=False,
                      verbose=False):
     """
@@ -50,6 +50,10 @@ def surface_phot(label, center_ra, center_dec, major_diam, minor_diam, pos_angle
     aperture_factor : float (default=1.0)
         make the aperture larger by a factor of N (useful to quickly adjust
         aperture if, e.g., you know R25 is too small for your UV galaxy)
+
+    sky_aperture_factor : float (default=1.0)
+        choose whether the sky aperture starts at the edge of the photometry
+        aperture (1.0) or some factor N larger
 
     mask_file : string (default=None)
         path+name of ds9 region file with masks
@@ -115,7 +119,7 @@ def surface_phot(label, center_ra, center_dec, major_diam, minor_diam, pos_angle
         # -------------------------
 
         # size of sky annulus
-        sky_in = annulus_array[-1]
+        sky_in = annulus_array[-1] * sky_aperture_factor
         sky_ann_width = ann_width * 10
         sky_out = sky_in + sky_ann_width
 

--- a/uvot-galphot/surface_phot.py
+++ b/uvot-galphot/surface_phot.py
@@ -1,5 +1,6 @@
 import numpy as np
 import matplotlib.pyplot as plt
+import os
 
 from photutils import SkyEllipticalAperture, SkyEllipticalAnnulus, aperture_photometry, EllipticalAnnulus, EllipticalAperture
 from astropy.io import fits
@@ -71,6 +72,12 @@ def surface_phot(label, center_ra, center_dec, major_diam, minor_diam, pos_angle
     counts_im = label + 'sk.fits'
     exp_im = label + 'ex.fits'
     offset_im = label + 'sk_off.fits'
+
+    # if files don't exist, return NaN
+    if (not os.path.isfile(counts_im)) or (not os.path.isfile(exp_im)):
+        print('surface_phot: image(s) not found')
+        return np.nan
+    
 
     with fits.open(counts_im) as hdu_counts, fits.open(exp_im) as hdu_ex:
 


### PR DESCRIPTION
This does a bunch of things in `surface_phot.py`:
* optional inputs for scaling factors for the aperture size and the sky aperture size (relative to aperture size)
* if images aren't found for the given input filter, return NaN
* do checks for spurious NaN in counts image (in addition to existing check for offset image), and mask them if they're found
* change procedure for masking from ds9 region file: use various [regions methods](https://astropy-regions.readthedocs.io/en/latest/shapes.html), which allows for arbitrary region shapes (not just circles)